### PR TITLE
ops: add db/app healthchecks; run alembic before app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,14 @@ services:
   app:
     build: .
     ports:
-      - "8501:8501"   # Streamlit UI
-      - "8000:8000"   # FastAPI
+      - "8501:8501"
+      - "8000:8000"
     env_file: .env
     depends_on:
-      - db
-      - mailhog
+      db:
+        condition: service_healthy
+      mailhog:
+        condition: service_started
 
   db:
     image: postgres:15
@@ -17,6 +19,11 @@ services:
       - dbdata:/var/lib/postgresql/data
     ports:
       - "55432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 3s
+      retries: 15
 
   mailhog:
     image: mailhog/mailhog

--- a/start.sh
+++ b/start.sh
@@ -1,11 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# DB migrate
-alembic upgrade head
+python - <<'PY'
+import os, time, sys
+import psycopg
+url = os.getenv("DATABASE_URL", "sqlite:///state/db.sqlite")
+if url.startswith("postgres"):
+    for i in range(60):
+        try:
+            with psycopg.connect(os.getenv("DATABASE_URL").replace("+psycopg",""), connect_timeout=3) as _:
+                break
+        except Exception:
+            time.sleep(1)
+    else:
+        sys.exit("DB not ready")
+PY
 
-# API
+alembic -c alembic.ini upgrade head
+
 uvicorn api.server:app --host 0.0.0.0 --port 8000 &
-
-# UI (Streamlit)
 exec streamlit run apps/jarvis_ui/app.py --server.port 8501 --server.address 0.0.0.0


### PR DESCRIPTION
Docker Compose: DB healthcheck + app healthcheck (/manifest.json).

start.sh: Postgres’e bağlanana kadar bekle, sonra alembic upgrade head.

Uvicorn & Streamlit aynı.